### PR TITLE
solved 트리의지름 - 112ms 9.9mb

### DIFF
--- a/Baekjoon/트리의지름/트리의지름_조은영.cpp
+++ b/Baekjoon/트리의지름/트리의지름_조은영.cpp
@@ -1,0 +1,87 @@
+#include <iostream>
+#include <vector>
+#include <stack>
+#include <sstream>
+using namespace std;
+
+int N, node, edge, linked_node;
+
+stack<pair<int, int>>st; // 노드, 
+int last_node, sum;
+
+int main() {
+
+	ios_base::sync_with_stdio(false);
+	cin.tie(0);
+
+	cin >> N;
+	cin.ignore();
+
+	vector <vector< pair<int, int >> > graph(N+1);
+	bool *visited = new bool[N + 1];
+
+	for (int i = 0; i < N; i++) {
+		string line = "";
+		getline(cin, line);
+		istringstream iss(line);
+		
+		iss >> node;
+
+		while (iss >> linked_node && linked_node != -1) {
+			iss >> edge;
+			graph[node].push_back({ linked_node, edge });
+		}
+	}
+
+	st.push({ 1,0 });
+	visited[1] = true;
+	int len = 0, start_node=0;
+
+	while (!st.empty()) {
+		int current_node = st.top().first;
+		int current_len = st.top().second;
+		st.pop();
+
+		// 간선 가중치가 더 높은 노드가 시작점 되어야함
+		if (len < current_len) {
+			start_node = current_node;
+			len = current_len;
+		}
+
+		for (int i = 0; i < graph[current_node].size(); i++) {
+			if (!visited[graph[current_node][i].first]) {
+				visited[graph[current_node][i].first] = true;
+				st.push({ graph[current_node][i].first, current_len+graph[current_node][i].second });
+			}
+		}
+	}
+
+	while (!st.empty()) st.pop();
+
+	// 거리 구하기
+	st.push({ start_node, 0 });
+	fill(visited, visited + N+1, false);
+	visited[start_node] = true;
+
+	int ans = 0;
+
+	while (!st.empty()) {
+		int current_node = st.top().first;
+		int current_len = st.top().second;
+		st.pop();
+
+		ans = max(ans, current_len);
+
+		for (int i = 0; i < graph[current_node].size(); i++) {
+			if (!visited[graph[current_node][i].first]) {
+				visited[graph[current_node][i].first] = true;
+				st.push({ graph[current_node][i].first, current_len+graph[current_node][i].second });
+			}
+		}
+	}
+
+
+	cout << ans << "\n";
+
+	return 0;
+}


### PR DESCRIPTION
## 💿 풀이 문제
#168 

## 📝 풀이 후기
어려웠습니다. 아이디어는 맞았는데 어떻게 구현할지 생각하는게 어려웠어요


## 📚 문제 풀이 핵심 키워드
- 루트노드에서 가장 먼 노드(깊이가 같다면 가중치가 가장 큰 노드)를 시작 노드로 잡고 시작 노드에서 가장 먼 노드까지의 길이가 답입니다. N크기가 커서 재귀로 dfs를 구현할 경우 시간초과가 날 수 있으므로 스택으로 구현했습니다.

## 🤔 리뷰로 궁금한 점

## 🧑‍💻 제출자 확인 사항
<!-- Merge가 되면, Branch를 꼭 삭제해주세요 -->
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?
